### PR TITLE
Change git URLs to https protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Zephyr advanced blinky example.
 
 # Initialize the project
 ```sh
-west init -m git@github.com:morandg/zephyr-blinky-advanced.git blinky-advanced
+west init -m https://github.com/morandg/zephyr-blinky-advanced.git blinky-advanced
 cd blinky-advanced
 west update 
 source zephyr/zephyr-env.sh

--- a/west.yml
+++ b/west.yml
@@ -1,7 +1,7 @@
 manifest:
   remotes:
     - name: zephyr
-      url-base: git@github.com:zephyrproject-rtos
+      url-base: https://github.com/zephyrproject-rtos
   projects:
     - name: zephyr
       remote: zephyr


### PR DESCRIPTION
Anyone should be able to clone the repository, even without a github account.

fix #2